### PR TITLE
Squash exceptions when recovering from a disconnected COM port.

### DIFF
--- a/adrilight/Util/SerialStream.cs
+++ b/adrilight/Util/SerialStream.cs
@@ -247,11 +247,18 @@ namespace adrilight
                     }
 
                     //to be safe, we reset the serial port
-                    if (serialPort != null && serialPort.IsOpen)
+                    try
                     {
-                        serialPort.Close();
+                        if (serialPort != null && serialPort.IsOpen)
+                        {
+                            serialPort.Close();
+                        }
+                        serialPort?.Dispose();
                     }
-                    serialPort?.Dispose();
+                    catch (Exception)
+                    {
+                        // possible IoException when device is unplugged
+                    }
                     serialPort = null;
 
                     //allow the system some time to recover


### PR DESCRIPTION
Thanks for this awesome project! I've been using it for months now.

This change squashes the IOException that sometimes happens when calling `serialPort.close()` on a COM port which no longer exists. This allows Adrilight to recover from USB disconnects more gracefully.

Here's how that unhandled exception looks on my system:
![image](https://user-images.githubusercontent.com/3418587/116595467-587b6a80-a8f1-11eb-9cf4-39484d01d497.png)

My use-case might not be that common. My Teensy 3.0 is plugged into my monitor's USB port so it sees a lot of power cycles. Each time, I have to manually restart adrilight.exe. Not a big deal, but allowing Adrilight to recover from this situation solves a minor nuisance.