### PR TITLE
Added Color Modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You have another idea for a feature? Please create an issue.
 
 ## Thanks
 
-* This is a fork from the originally ambilight clone project [bambilight by MrBoe](https://github.com/MrBoe/Bambilight) and therefore (and to met the MIT licence) a big thank you goes to [MrBoe](https://github.com/MrBoe)
+* This is an extended fork of a fork from the originally ambilight clone project [bambilight by MrBoe](https://github.com/MrBoe/Bambilight) and therefore (and to met the MIT licence) a big thank you goes to [MrBoe](https://github.com/MrBoe)
 * More thanks goes to [jasonpong](https://github.com/jasonpang) for his [sample code for the Desktop Duplication API](https://github.com/jasonpang/desktop-duplication-net)
 
 ## Changelog

--- a/adrilight.sln
+++ b/adrilight.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2015
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "adrilight", "adrilight\adrilight.csproj", "{1AB593C8-38E2-493B-B4B8-16BC406231AE}"
 EndProject

--- a/adrilight/App.xaml.cs
+++ b/adrilight/App.xaml.cs
@@ -22,6 +22,7 @@ using System.Windows;
 using System.Windows.Threading;
 using Ninject.Extensions.Conventions;
 using adrilight.Resources;
+using adrilight.Settings;
 using adrilight.Util;
 
 namespace adrilight
@@ -227,6 +228,8 @@ namespace adrilight
             var contextMenu = new System.Windows.Forms.ContextMenu();
             contextMenu.MenuItems.Add(CreateSendingMenuItem());
             
+            contextMenu.MenuItems.Add(CreateColorModeMenuItem());
+            
             contextMenu.MenuItems.Add(new System.Windows.Forms.MenuItem("Settings...", (s, e) => OpenSettingsWindow()));
             contextMenu.MenuItems.Add(new System.Windows.Forms.MenuItem("Exit", (s, e) => Shutdown(0)));
 
@@ -260,6 +263,32 @@ namespace adrilight
             UserSettings.PropertyChanged += (s, e) => { if (e.PropertyName == nameof(UserSettings.TransferActive)) { UpdateMenuItem(); } };
 
             return menuItem;
+        }
+
+        private System.Windows.Forms.MenuItem CreateColorModeMenuItem()
+        {
+            var modeMenuItem = new System.Windows.Forms.MenuItem("Color Mode");
+
+            foreach (ColorModeEnum mode in Enum.GetValues(typeof(ColorModeEnum)))
+            {
+                var modeItem = new System.Windows.Forms.MenuItem(mode.ToString(), (s, e) => UserSettings.ColorMode = mode);
+                
+
+                void UpdateMenuItem()
+                {
+                    modeItem.Checked = (mode == UserSettings.ColorMode);
+                }
+
+                //initial update
+                UpdateMenuItem();
+
+                //update on changed setting
+                UserSettings.PropertyChanged += (s, e) => { if (e.PropertyName == nameof(UserSettings.ColorMode)) { UpdateMenuItem(); } };
+
+                
+                modeMenuItem.MenuItems.Add(modeItem);
+            }
+            return modeMenuItem;
         }
 
         public static bool IsPrivateBuild { get; private set; }

--- a/adrilight/Fakes/UserSettingsFake.cs
+++ b/adrilight/Fakes/UserSettingsFake.cs
@@ -47,6 +47,7 @@ namespace adrilight.Fakes
         public string AdrilightVersion { get; set; } = "2.0.6";
 
         public AlternateWhiteBalanceModeEnum AlternateWhiteBalanceMode { get; set; } = AlternateWhiteBalanceModeEnum.Off;
+        public ColorModeEnum ColorMode { get; set; } = ColorModeEnum.Ambilight;
 #pragma warning disable CS0067
         public event PropertyChangedEventHandler PropertyChanged;
 #pragma warning restore CS0067

--- a/adrilight/Fakes/UserSettingsFake.cs
+++ b/adrilight/Fakes/UserSettingsFake.cs
@@ -51,5 +51,9 @@ namespace adrilight.Fakes
 #pragma warning disable CS0067
         public event PropertyChangedEventHandler PropertyChanged;
 #pragma warning restore CS0067
+        
+        public byte StaticColorModeRed { get; set; } = 100;
+        public byte StaticColorModeGreen { get; set; } = 100;
+        public byte StaticColorModeBlue { get; set; } = 100;
     }
 }

--- a/adrilight/Settings/ColorModeEnum.cs
+++ b/adrilight/Settings/ColorModeEnum.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace adrilight.Settings
+{
+    public enum ColorModeEnum
+    {
+        Ambilight = 0,
+        Static = 1,
+        Rainbow = 2
+    }
+}

--- a/adrilight/Settings/IUserSettings.cs
+++ b/adrilight/Settings/IUserSettings.cs
@@ -43,5 +43,9 @@ namespace adrilight
         string AdrilightVersion { get; set; }
         AlternateWhiteBalanceModeEnum AlternateWhiteBalanceMode { get; set; }
         ColorModeEnum ColorMode { get; set; }
+        
+        byte StaticColorModeRed { get; set; }
+        byte StaticColorModeGreen { get; set; }
+        byte StaticColorModeBlue { get; set; }
     }
 }

--- a/adrilight/Settings/IUserSettings.cs
+++ b/adrilight/Settings/IUserSettings.cs
@@ -42,5 +42,6 @@ namespace adrilight
 
         string AdrilightVersion { get; set; }
         AlternateWhiteBalanceModeEnum AlternateWhiteBalanceMode { get; set; }
+        ColorModeEnum ColorMode { get; set; }
     }
 }

--- a/adrilight/Settings/UserSettings.cs
+++ b/adrilight/Settings/UserSettings.cs
@@ -45,6 +45,10 @@ namespace adrilight
         private AlternateWhiteBalanceModeEnum _alternateWhiteBalanceModeEnum = AlternateWhiteBalanceModeEnum.Off;
         private ColorModeEnum _colorModeEnum = ColorModeEnum.Ambilight;
 
+        private byte _staticColorModeRed = 100;
+        private byte _staticColorModeGreen = 100;
+        private byte _staticColorModeBlue = 100;
+
         //support future config file migration
         public int ConfigFileVersion { get => _configFileVersion; set { Set(() => ConfigFileVersion, ref _configFileVersion, value); } }
 
@@ -86,5 +90,10 @@ namespace adrilight
         public AlternateWhiteBalanceModeEnum AlternateWhiteBalanceMode { get => _alternateWhiteBalanceModeEnum; set { Set(() => AlternateWhiteBalanceMode, ref _alternateWhiteBalanceModeEnum, value); } }
 
         public ColorModeEnum ColorMode { get => _colorModeEnum; set { Set(() => ColorMode, ref _colorModeEnum, value); } }
+        
+        public byte StaticColorModeRed { get => _staticColorModeRed; set { Set(() => StaticColorModeRed, ref _staticColorModeRed, value); } }
+        public byte StaticColorModeGreen { get => _staticColorModeGreen; set { Set(() => StaticColorModeGreen, ref _staticColorModeGreen, value); } }
+        public byte StaticColorModeBlue { get => _staticColorModeBlue; set { Set(() => StaticColorModeBlue, ref _staticColorModeBlue, value); } }
+
     }
 }

--- a/adrilight/Settings/UserSettings.cs
+++ b/adrilight/Settings/UserSettings.cs
@@ -42,7 +42,8 @@ namespace adrilight
         private bool _sendRandomColors = false;
         private int _limitFps = 60;
         private int _configFileVersion = 2;
-        private AlternateWhiteBalanceModeEnum _alternateWhiteBalanceMode = AlternateWhiteBalanceModeEnum.Off;
+        private AlternateWhiteBalanceModeEnum _alternateWhiteBalanceModeEnum = AlternateWhiteBalanceModeEnum.Off;
+        private ColorModeEnum _colorModeEnum = ColorModeEnum.Ambilight;
 
         //support future config file migration
         public int ConfigFileVersion { get => _configFileVersion; set { Set(() => ConfigFileVersion, ref _configFileVersion, value); } }
@@ -82,6 +83,8 @@ namespace adrilight
         public bool SendRandomColors { get => _sendRandomColors; set { Set(() => SendRandomColors, ref _sendRandomColors, value); } }
 
         public Guid InstallationId { get; set; } = Guid.NewGuid();
-        public AlternateWhiteBalanceModeEnum AlternateWhiteBalanceMode { get => _alternateWhiteBalanceMode; set { Set(() => AlternateWhiteBalanceMode, ref _alternateWhiteBalanceMode, value); } }
+        public AlternateWhiteBalanceModeEnum AlternateWhiteBalanceMode { get => _alternateWhiteBalanceModeEnum; set { Set(() => AlternateWhiteBalanceMode, ref _alternateWhiteBalanceModeEnum, value); } }
+
+        public ColorModeEnum ColorMode { get => _colorModeEnum; set { Set(() => ColorMode, ref _colorModeEnum, value); } }
     }
 }

--- a/adrilight/View/SettingsWindowComponents/ColorModeSetup.xaml
+++ b/adrilight/View/SettingsWindowComponents/ColorModeSetup.xaml
@@ -26,7 +26,7 @@
             <ColumnDefinition Width="1*" />
         </Grid.ColumnDefinitions>
 
-        <materialDesign:Card Margin="4 4 2 4" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Stretch">
+        <materialDesign:Card Margin="4 4 2 4" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Stretch">
             <StackPanel Margin="38 28 38 18">
                 <TextBlock Margin="2,-10,72.4,49.4" FontWeight="Bold"
                            RenderTransformOrigin="0.5,0.5" Foreground="#FFFD7474" TextDecorations="{x:Null}">
@@ -48,6 +48,49 @@
                           SelectedValue="{Binding Settings.ColorMode, Mode=TwoWay}"/>
 
             </StackPanel>
+        </materialDesign:Card>
+        
+        <materialDesign:Card Margin="4 4 2 4" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Stretch">
+                
+            <Grid Margin="38 28 8 38">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="auto" />
+                    <ColumnDefinition Width="auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.ColumnSpan="3" VerticalAlignment="Bottom" FontWeight="Bold">
+                    Static Color
+                </TextBlock>
+
+                <TextBlock Grid.Row="1" VerticalAlignment="Bottom">Red</TextBlock>
+                <TextBlock Grid.Row="2" VerticalAlignment="Bottom">Green</TextBlock>
+                <TextBlock Grid.Row="3" VerticalAlignment="Bottom">Blue</TextBlock>
+
+                <Slider Grid.Row="1" Grid.Column="1" Width="200" 
+                    Minimum="1" Maximum="100" Value="{Binding Settings.StaticColorModeRed}" 
+                    Style="{StaticResource MaterialDesignDiscreteSlider}" 
+                                 />
+                <Slider Grid.Row="2" Grid.Column="1" Width="200" 
+                    Minimum="1" Maximum="100" Value="{Binding Settings.StaticColorModeGreen}" 
+                    Style="{StaticResource MaterialDesignDiscreteSlider}" 
+                                 />
+                <Slider Grid.Row="3" Grid.Column="1" Width="200"
+                    Minimum="1" Maximum="100" Value="{Binding Settings.StaticColorModeBlue}" 
+                    Style="{StaticResource MaterialDesignDiscreteSlider}" 
+                                 />
+
+                <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding Settings.StaticColorModeRed}" VerticalAlignment="Bottom" />
+                <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding Settings.StaticColorModeGreen}" VerticalAlignment="Bottom" />
+                <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding Settings.StaticColorModeBlue}" VerticalAlignment="Bottom" />
+            </Grid>
+
         </materialDesign:Card>
     </Grid>
 </UserControl>

--- a/adrilight/View/SettingsWindowComponents/ColorModeSetup.xaml
+++ b/adrilight/View/SettingsWindowComponents/ColorModeSetup.xaml
@@ -1,0 +1,53 @@
+﻿<UserControl x:Class="adrilight.View.SettingsWindowComponents.ColorModeSetup"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal" 
+        TextOptions.TextRenderingMode="Auto"        
+        Background="{DynamicResource MaterialDesignPaper}"
+        FontFamily="{StaticResource MaterialDesignFont}"
+             
+             d:DesignHeight="900" d:DesignWidth="900">
+    <Grid Width="900">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*" />
+            <ColumnDefinition Width="1*" />
+        </Grid.ColumnDefinitions>
+
+        <materialDesign:Card Margin="4 4 2 4" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Stretch">
+            <StackPanel Margin="38 28 38 18">
+                <TextBlock Margin="2,-10,72.4,49.4" FontWeight="Bold"
+                           RenderTransformOrigin="0.5,0.5" Foreground="#FFFD7474" TextDecorations="{x:Null}">
+                    <TextBlock.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform/>
+                            <SkewTransform/>
+                            <RotateTransform Angle="-7.268"/>
+                            <TranslateTransform/>
+                        </TransformGroup>
+                    </TextBlock.RenderTransform>EXPERIMENTAL!</TextBlock>
+                <TextBlock Margin="58 18 38 8" FontWeight="bold">Selected color mode:</TextBlock>
+                <ComboBox Margin="58 0 0 40" 
+                          Width="150" 
+                          HorizontalAlignment="Left" 
+                          ItemsSource="{Binding ColorModes}"
+                          DisplayMemberPath="Value"
+                          SelectedValuePath="Key"
+                          SelectedValue="{Binding Settings.ColorMode, Mode=TwoWay}"/>
+
+            </StackPanel>
+        </materialDesign:Card>
+    </Grid>
+</UserControl>

--- a/adrilight/View/SettingsWindowComponents/ColorModeSetup.xaml.cs
+++ b/adrilight/View/SettingsWindowComponents/ColorModeSetup.xaml.cs
@@ -17,29 +17,29 @@ using System.Windows.Shapes;
 namespace adrilight.View.SettingsWindowComponents
 {
     /// <summary>
-    /// Interaction logic for LightingMode.xaml
+    /// Interaction logic for ColorModeSetup.xaml
     /// </summary>
-    public partial class Whitebalance : UserControl
+    public partial class ColorModeSetup : UserControl
     {
-        public Whitebalance()
+        public ColorModeSetup()
         {
             InitializeComponent();
         }
 
 
 
-        public class WhitebalanceSelectableViewPart : ISelectableViewPart
+        public class ColorModeSelectableViewPart : ISelectableViewPart
         {
-            private readonly Lazy<Whitebalance> lazyContent;
+            private readonly Lazy<ColorModeSetup> lazyContent;
 
-            public WhitebalanceSelectableViewPart(Lazy<Whitebalance> lazyContent)
+            public ColorModeSelectableViewPart(Lazy<ColorModeSetup> lazyContent)
             {
                 this.lazyContent = lazyContent ?? throw new ArgumentNullException(nameof(lazyContent));
             }
 
-            public int Order => 900;
+            public int Order => 800;
 
-            public string ViewPartName => "White Balance";
+            public string ViewPartName => "Color Mode";
 
             public object Content { get => lazyContent.Value; }
         }

--- a/adrilight/View/SettingsWindowComponents/Whitebalance.xaml
+++ b/adrilight/View/SettingsWindowComponents/Whitebalance.xaml
@@ -137,7 +137,7 @@
 
         <materialDesign:Card Margin="4 4 2 4" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Stretch">
             <StackPanel Margin="38 28 38 18">
-                <TextBlock FontWeight="bold">Controling alternate night light mode detection/usage:</TextBlock>
+                <TextBlock FontWeight="bold">Controlling alternate night light mode detection/usage:</TextBlock>
 
                 <TextBlock Margin="58 18 38 8" FontWeight="bold">Selected mode:</TextBlock>
                 <ComboBox Margin="58 0 0 40" 

--- a/adrilight/ViewModel/SettingsViewModel.cs
+++ b/adrilight/ViewModel/SettingsViewModel.cs
@@ -20,6 +20,7 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Color = System.Drawing.Color;
 
 namespace adrilight.ViewModel
 {
@@ -296,6 +297,13 @@ namespace adrilight.ViewModel
                 {AlternateWhiteBalanceModeEnum.On, "Forced On" },
                 {AlternateWhiteBalanceModeEnum.Auto, "Auto detect" },
                 {AlternateWhiteBalanceModeEnum.Off, "Forced Off" },
+            };
+        
+        public IDictionary<ColorModeEnum, string> ColorModes { get; } =
+            new SortedDictionary<ColorModeEnum, string>() {
+                {ColorModeEnum.Ambilight, "Ambilight" },
+                {ColorModeEnum.Static, "Static" },
+                {ColorModeEnum.Rainbow, "Rainbow" },
             };
     }
 }

--- a/adrilight/adrilight.csproj
+++ b/adrilight/adrilight.csproj
@@ -291,6 +291,7 @@
     <Compile Include="Fakes\SpotSetFake.cs" />
     <Compile Include="Fakes\UserSettingsFake.cs" />
     <Compile Include="DesktopDuplication\IDesktopDuplicatorReader.cs" />
+    <Compile Include="Settings\ColorModeEnum.cs" />
     <Compile Include="Settings\AlternateWhiteBalanceModeEnum.cs" />
     <Compile Include="Util\ColorUtil.cs" />
     <Compile Include="Util\FakeSerialPort.cs" />

--- a/adrilight/adrilight.csproj
+++ b/adrilight/adrilight.csproj
@@ -326,6 +326,9 @@
     <Compile Include="ValidationRules\NumberRangeValidationRule.cs" />
     <Compile Include="ViewModel\SettingsViewModel.cs" />
     <Compile Include="ViewModel\ValidationRules\NotEmptyValidationRule.cs" />
+    <Compile Include="View\SettingsWindowComponents\ColorModeSetup.xaml.cs">
+      <DependentUpon>ColorModeSetup.xaml</DependentUpon>
+    </Compile>
     <Compile Include="View\SettingsWindowComponents\WhatsNew.xaml.cs">
       <DependentUpon>WhatsNew.xaml</DependentUpon>
     </Compile>
@@ -389,6 +392,10 @@
     </ApplicationDefinition>
   </ItemGroup>
   <ItemGroup>
+    <Page Include="View\SettingsWindowComponents\ColorModeSetup.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="View\SettingsWindowComponents\WhatsNew.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
This pull request aims to add some new options / modes that were previously suggested and make sense to have as an alternative to re-flashing the Nano each time.
The color modes overwrite the colors calculated from screen/spot color capturing

Planned Modes / Progress
- [x] Screen zones (the default ambilight behavior)
- [x] Static Color - set all LEDs to a specific color
- [ ] Rainbow - similar to the "random colors" option, but with styles (wave, circle, ping pong)
- [ ] Music - capture audio and change colors accordingly
- [ ] Sleep - for when the monitor is off

Planned Features
- [ ] Proper color input fields (alternative to sliders)
- [ ] Auto mode switching (i.e. when an app is detected to be running)


#109 #50 #53 #65 